### PR TITLE
Fixes #190 - Workaround for service apply bug

### DIFF
--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -260,18 +260,18 @@ class ServiceApplyRule(Icinga2APIObject):
         if ret["code"] == 200:
             for existing_rule in ret["data"]["objects"]:
                 if existing_rule["object_name"] == self.data["object_name"]:
-                    self.object_id = existing_rule["id"]
+                    self.object_id = existing_rule["uuid"]
                     return self.object_id
         return False
 
     def delete(self):
-        return super(ServiceApplyRule, self).delete(find_by="id")
+        return super(ServiceApplyRule, self).delete(find_by="uuid")
 
     def modify(self):
-        return super(ServiceApplyRule, self).modify(find_by="id")
+        return super(ServiceApplyRule, self).modify(find_by="uuid")
 
     def diff(self):
-        return super(ServiceApplyRule, self).diff(find_by="id")
+        return super(ServiceApplyRule, self).diff(find_by="uuid")
 
 
 # ===========================================

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -262,7 +262,7 @@ class ServiceApplyRule(Icinga2APIObject):
         if ret["code"] == 200:
             for existing_rule in ret["data"]["objects"]:
                 if existing_rule["object_name"] == self.data["object_name"]:
-                    if existing_rule["uuid"] is not None:
+                    if "uuid" in existing_rule and existing_rule["uuid"] is not None:
                         self.find_by_parameter = "uuid"
                     else:
                         # self.object_id = existing_rule["id"]

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -251,33 +251,34 @@ from ansible_collections.telekom_mms.icinga_director.plugins.module_utils.icinga
 # Icinga2 API class
 #
 class ServiceApplyRule(Icinga2APIObject):
+    find_by_parameter = None
     def __init__(self, module, data):
         path = "/service"
         super(ServiceApplyRule, self).__init__(module, path, data)
 
     def exists(self):
-        global find_by_value
+        # global FINDBY
         ret = self.call_url(path="/serviceapplyrules")
         if ret["code"] == 200:
             for existing_rule in ret["data"]["objects"]:
                 if existing_rule["object_name"] == self.data["object_name"]:
-                  if existing_rule["uuid"] != None:
-                    self.object_id = existing_rule["uuid"]
-                    find_by_value = "uuid"
-                  else:
-                    self.object_id = existing_rule["id"]
-                    find_by_value = "id"
-                  return self.object_id
+                    if existing_rule["uuid"] is not None:
+                        self.find_by_parameter = "uuid"
+                    else:
+                        # self.object_id = existing_rule["id"]
+                        self.find_by_parameter = "id"
+                    self.object_id = existing_rule[self.find_by_parameter]
+                    return self.object_id
         return False
 
     def delete(self):
-        return super(ServiceApplyRule, self).delete(find_by=find_by_value)
+        return super(ServiceApplyRule, self).delete(find_by=self.find_by_parameter)
 
     def modify(self):
-        return super(ServiceApplyRule, self).modify(find_by=find_by_value)
+        return super(ServiceApplyRule, self).modify(find_by=self.find_by_parameter)
 
     def diff(self):
-        return super(ServiceApplyRule, self).diff(find_by=find_by_value)
+        return super(ServiceApplyRule, self).diff(find_by=self.find_by_parameter)
 
 
 # ===========================================

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -256,22 +256,28 @@ class ServiceApplyRule(Icinga2APIObject):
         super(ServiceApplyRule, self).__init__(module, path, data)
 
     def exists(self):
+        global find_by_value
         ret = self.call_url(path="/serviceapplyrules")
         if ret["code"] == 200:
             for existing_rule in ret["data"]["objects"]:
                 if existing_rule["object_name"] == self.data["object_name"]:
+                  if existing_rule["uuid"] != None:
                     self.object_id = existing_rule["uuid"]
-                    return self.object_id
+                    find_by_value = "uuid"
+                  else:
+                    self.object_id = existing_rule["id"]
+                    find_by_value = "id"
+                  return self.object_id
         return False
 
     def delete(self):
-        return super(ServiceApplyRule, self).delete(find_by="uuid")
+        return super(ServiceApplyRule, self).delete(find_by=find_by_value)
 
     def modify(self):
-        return super(ServiceApplyRule, self).modify(find_by="uuid")
+        return super(ServiceApplyRule, self).modify(find_by=find_by_value)
 
     def diff(self):
-        return super(ServiceApplyRule, self).diff(find_by="uuid")
+        return super(ServiceApplyRule, self).diff(find_by=find_by_value)
 
 
 # ===========================================

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -252,12 +252,12 @@ from ansible_collections.telekom_mms.icinga_director.plugins.module_utils.icinga
 #
 class ServiceApplyRule(Icinga2APIObject):
     find_by_parameter = None
+
     def __init__(self, module, data):
         path = "/service"
         super(ServiceApplyRule, self).__init__(module, path, data)
 
     def exists(self):
-        # global FINDBY
         ret = self.call_url(path="/serviceapplyrules")
         if ret["code"] == 200:
             for existing_rule in ret["data"]["objects"]:
@@ -265,7 +265,6 @@ class ServiceApplyRule(Icinga2APIObject):
                     if "uuid" in existing_rule and existing_rule["uuid"] is not None:
                         self.find_by_parameter = "uuid"
                     else:
-                        # self.object_id = existing_rule["id"]
                         self.find_by_parameter = "id"
                     self.object_id = existing_rule[self.find_by_parameter]
                     return self.object_id


### PR DESCRIPTION
Fixes #190 

I've found that changing all instances of 'find_by="id"' field with 'find_by="uuid"', in the ServiceApplyClass, actually made the error disappear. Unfortunately at this time I've only a completely empty Icinga installation, so I can't use the service apply created to any host, but 'm able to perform operations on Service Apply
If you run some test with my fix the error is not present and you are now able to Add/Delete service apply in idempotent way

What do you think?

Thanks