### PR TITLE
Add vars parameter to notification templates, task icinga_serviceset swap

### DIFF
--- a/docs/icinga_notification_template.rst
+++ b/docs/icinga_notification_template.rst
@@ -75,6 +75,8 @@ Parameters
   user_groups (optional, list, None)
     User Groups that should be notified by this notification.
 
+  vars (optional, dict, {})
+    Custom properties of the notification.
 
   append (optional, bool, None)
     Do not overwrite the whole object but instead append the defined properties.
@@ -169,7 +171,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
+
     - name: Create notification template
       telekom_mms.icinga_director.icinga_notification_template:
         state: present
@@ -191,6 +193,8 @@ Examples
           - "rb"
         user_groups:
           - "OnCall"
+        vars:
+          foo: bar
         zone: "foozone"
 
     - name: Update notification template
@@ -201,6 +205,8 @@ Examples
         url_password: "{{ icinga_pass }}"
         object_name: foonotificationtemplate
         notification_interval: '0'
+        vars:
+          foo: bar
         append: true
 
 

--- a/examples/icinga_notification_template.yml
+++ b/examples/icinga_notification_template.yml
@@ -20,6 +20,8 @@
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
 - name: Update notification template
   telekom_mms.icinga_director.icinga_notification_template:
@@ -29,4 +31,6 @@
     url_password: "{{ icinga_pass }}"
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -115,6 +115,12 @@ options:
       - Required if I(state) is C(present).
     type: "list"
     elements: str
+  vars:
+    description:
+      - Custom properties of the notification.
+    type: "dict"
+    version_added: "2.2.x"
+    default: {}
 """
 
 EXAMPLES = """
@@ -139,6 +145,8 @@ EXAMPLES = """
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
 
 - name: Update notification template
@@ -149,6 +157,8 @@ EXAMPLES = """
     url_password: "{{ icinga_pass }}"
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true
 """
 
@@ -185,6 +195,7 @@ def main():
         command=dict(required=False, aliases=["notification_command"]),
         users=dict(type="list", elements="str", required=False),
         user_groups=dict(type="list", elements="str", required=False),
+        vars=dict(type="dict", default={}, required=False),
     )
 
     # Define the main module
@@ -206,6 +217,7 @@ def main():
         "command",
         "users",
         "user_groups",
+        "vars"
     ]
 
     data = {}

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -119,7 +119,6 @@ options:
     description:
       - Custom properties of the notification.
     type: "dict"
-    version_added: "2.2.2"
     default: {}
 """
 

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -119,7 +119,7 @@ options:
     description:
       - Custom properties of the notification.
     type: "dict"
-    version_added: "2.2.x"
+    version_added: "2.2.2"
     default: {}
 """
 

--- a/roles/ansible_icinga/tasks/icinga_notification_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_notification_template.yml
@@ -21,6 +21,7 @@
     user_groups: "{{ notification_template.user_groups | default(omit) }}"
     notification_command: "{{ notification_template.notification_command | default(omit) }}"
     imports: "{{ notification_template.imports | default(omit) }}"
+    vars: "{{ notification_template.vars | default(omit) }}"
     zone: "{{ notification_template.zone | default(omit) }}"
   retries: 3
   delay: 3

--- a/roles/ansible_icinga/tasks/main.yml
+++ b/roles/ansible_icinga/tasks/main.yml
@@ -69,15 +69,15 @@
   when: icinga_servicegroups is defined
   tags: servicegroup
 
-- name: Icinga service configuration
-  ansible.builtin.include_tasks: icinga_service.yml
-  when: icinga_services is defined
-  tags: service
-
 - name: Icinga serviceset configuration
   ansible.builtin.include_tasks: icinga_serviceset.yml
   when: icinga_servicesets is defined
   tags: serviceset
+
+- name: Icinga service configuration
+  ansible.builtin.include_tasks: icinga_service.yml
+  when: icinga_services is defined
+  tags: service
 
 - name: Icinga notification template configuration
   ansible.builtin.include_tasks: icinga_notification_template.yml

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_notification_template.yml
@@ -20,6 +20,8 @@
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
 - name: Update notification template
   telekom_mms.icinga_director.icinga_notification_template:
@@ -29,4 +31,6 @@
     url_password: "{{ icinga_pass }}"
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_template.yml
@@ -20,6 +20,8 @@
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
 - name: Update notification template
   telekom_mms.icinga_director.icinga_notification_template:
@@ -29,4 +31,6 @@
     url_password: "{{ icinga_pass }}"
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification_template.yml
@@ -20,6 +20,8 @@
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
   ignore_errors: true
   register: result
@@ -36,6 +38,8 @@
     url_password: "{{ icinga_pass }}"
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true
   ignore_errors: true
   register: result

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template.yml
@@ -20,6 +20,8 @@
       - "rb"
     user_groups:
       - "OnCall"
+    vars:
+      foo: bar
     zone: "foozone"
   ignore_errors: true
   register: result
@@ -36,6 +38,8 @@
     url_password: iamwrong
     object_name: foonotificationtemplate
     notification_interval: '0'
+    vars:
+      foo: bar
     append: true
   ignore_errors: true
   register: result


### PR DESCRIPTION
Hi,
The `icinga_notification_template` module doesn't have the possiblity to add `vars` to template, so I've implemented it and tested.

Also, while testing a complete recovery for my personal cluster, I've found that on the main task of the role, the `icinga_serviceset` is called after `icinga_service`, and that is a problem because every service connected to a serviceset, needs the `service_set` parameter, so I simply swapped the order, first service sets task and next the services task

Thanks