### PR TITLE
Add API timeout option for all modules

### DIFF
--- a/docs/icinga_hostgroup.rst
+++ b/docs/icinga_hostgroup.rst
@@ -50,6 +50,10 @@ Parameters
     Note - Variables that are set by default will also be applied, even if not set.
 
 
+  timeout (optional, int, 10)
+    Default timeout to wait for transaction to finish in seconds.
+
+
   url (True, str, None)
     HTTP, HTTPS, or FTP URL in the form (http\|https\|ftp)://[user[:pass]]@host.domain[:port]/path
 

--- a/docs/icinga_hostgroup.rst
+++ b/docs/icinga_hostgroup.rst
@@ -50,7 +50,7 @@ Parameters
     Note - Variables that are set by default will also be applied, even if not set.
 
 
-  timeout (optional, int, 10)
+  api_timeout (optional, int, 10)
     Default timeout to wait for transaction to finish in seconds.
 
 

--- a/plugins/doc_fragments/common_options.py
+++ b/plugins/doc_fragments/common_options.py
@@ -27,4 +27,9 @@ class ModuleDocFragment(object):
     options:
       url:
         required: true
+      api_timeout:
+        description:
+          - Default timeout to wait for transaction to finish in seconds.
+        default: 10
+        type: int
      """

--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -42,6 +42,7 @@ class Icinga2APIObject(object):
             "X-HTTP-Method-Override": method,
         }
         url = self.module.params.get("url") + "/director" + path
+        timeout = self.module.params.get("timeout", 10)
         rsp, info = fetch_url(
             module=self.module,
             url=url,
@@ -49,6 +50,7 @@ class Icinga2APIObject(object):
             headers=headers,
             method=method,
             use_proxy=self.module.params["use_proxy"],
+            timeout=timeout,
         )
         content = ""
         error = ""

--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -42,7 +42,7 @@ class Icinga2APIObject(object):
             "X-HTTP-Method-Override": method,
         }
         url = self.module.params.get("url") + "/director" + path
-        timeout = self.module.params.get("timeout", 10)
+        api_timeout = self.module.params.get("api_timeout", 10)
         rsp, info = fetch_url(
             module=self.module,
             url=url,
@@ -50,7 +50,7 @@ class Icinga2APIObject(object):
             headers=headers,
             method=method,
             use_proxy=self.module.params["use_proxy"],
-            timeout=timeout,
+            timeout=api_timeout,
         )
         content = ""
         error = ""

--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -238,6 +238,7 @@ def main():
         timeout=dict(required=False, default=None),
         zone=dict(required=False, default=None),
         arguments=dict(type="dict", default=None),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_command_info.py
+++ b/plugins/modules/icinga_command_info.py
@@ -96,6 +96,7 @@ def main():
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
         external=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_command_template.py
+++ b/plugins/modules/icinga_command_template.py
@@ -218,6 +218,7 @@ def main():
         timeout=dict(required=False, default=None),
         zone=dict(required=False, default=None),
         arguments=dict(type="dict", default=None),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_command_template_info.py
+++ b/plugins/modules/icinga_command_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_dependency_apply.py
+++ b/plugins/modules/icinga_dependency_apply.py
@@ -199,7 +199,8 @@ def main():
             default=[],
             required=False,
             choices=["Critical", "Down", "OK", "Unknown", "Up", "Warning"]
-        )
+        ),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_dependency_template.py
+++ b/plugins/modules/icinga_dependency_template.py
@@ -171,7 +171,8 @@ def main():
             default=[],
             required=False,
             choices=["Critical", "Down", "OK", "Unknown", "Up", "Warning"]
-        )
+        ),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_deploy.py
+++ b/plugins/modules/icinga_deploy.py
@@ -78,7 +78,8 @@ def main():
     # add our own arguments
     argument_spec.update(
         url=dict(required=True),
-        timeout=dict(required=False, default=2, type="int")
+        timeout=dict(required=False, default=2, type="int"),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_deploy_info.py
+++ b/plugins/modules/icinga_deploy_info.py
@@ -105,6 +105,7 @@ def main():
         url=dict(required=True),
         configs=dict(type="list", required=False, default=None, elements="str"),
         activities=dict(type="list", required=False, default=None, elements="str"),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_endpoint.py
+++ b/plugins/modules/icinga_endpoint.py
@@ -127,6 +127,7 @@ def main():
         port=dict(required=False, type="int"),
         log_duration=dict(required=False),
         zone=dict(required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_endpoint_info.py
+++ b/plugins/modules/icinga_endpoint_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -363,6 +363,7 @@ def main():
         vars=dict(type="dict", default=None),
         volatile=dict(type="bool", choices=[True, False], required=False),
         zone=dict(required=False, default=None),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_host_info.py
+++ b/plugins/modules/icinga_host_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_host_template.py
+++ b/plugins/modules/icinga_host_template.py
@@ -359,6 +359,7 @@ def main():
         vars=dict(type="dict", default=None),
         volatile=dict(type="bool", choices=[True, False], required=False),
         zone=dict(required=False, default=None),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_host_template_info.py
+++ b/plugins/modules/icinga_host_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -65,7 +65,7 @@ options:
     type: bool
     choices: [true, false]
     version_added: '1.25.0'
-  timeout:
+  api_timeout:
     description:
       - Default timeout to wait for transaction to finish in seconds.
     default: 10
@@ -130,7 +130,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         assign_filter=dict(required=False),
-        timeout=dict(required=False, default=10, type="int"),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -65,11 +65,6 @@ options:
     type: bool
     choices: [true, false]
     version_added: '1.25.0'
-  api_timeout:
-    description:
-      - Default timeout to wait for transaction to finish in seconds.
-    default: 10
-    type: int
 """
 
 EXAMPLES = """

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -65,6 +65,11 @@ options:
     type: bool
     choices: [true, false]
     version_added: '1.25.0'
+  timeout:
+    description:
+      - Default timeout to wait for deployment to finish in seconds.
+    default: 10
+    type: int
 """
 
 EXAMPLES = """
@@ -125,6 +130,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         assign_filter=dict(required=False),
+        timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -67,7 +67,7 @@ options:
     version_added: '1.25.0'
   timeout:
     description:
-      - Default timeout to wait for deployment to finish in seconds.
+      - Default timeout to wait for transaction to finish in seconds.
     default: 10
     type: int
 """

--- a/plugins/modules/icinga_hostgroup_info.py
+++ b/plugins/modules/icinga_hostgroup_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -232,6 +232,7 @@ def main():
         period=dict(required=False, aliases=["time_period"]),
         times_begin=dict(type="int", required=False),
         times_end=dict(type="int", required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_notification_info.py
+++ b/plugins/modules/icinga_notification_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -195,6 +195,7 @@ def main():
         users=dict(type="list", elements="str", required=False),
         user_groups=dict(type="list", elements="str", required=False),
         vars=dict(type="dict", default={}, required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_notification_template_info.py
+++ b/plugins/modules/icinga_notification_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_scheduled_downtime.py
+++ b/plugins/modules/icinga_scheduled_downtime.py
@@ -189,6 +189,7 @@ def main():
         fixed=dict(type="bool", choices=[True, False], default=False),
         ranges=dict(type="dict", required=False, default={}),
         with_services=dict(type="bool", default=True, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -327,6 +327,7 @@ def main():
         use_agent=dict(type="bool", required=False),
         vars=dict(type="dict", default={}, required=False),
         volatile=dict(type="bool", required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -313,6 +313,7 @@ def main():
         vars=dict(type="dict", default={}),
         notes=dict(type="str", required=False),
         notes_url=dict(type="str", required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service_apply_info.py
+++ b/plugins/modules/icinga_service_apply_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service_info.py
+++ b/plugins/modules/icinga_service_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service_template.py
+++ b/plugins/modules/icinga_service_template.py
@@ -265,6 +265,7 @@ def main():
         use_agent=dict(type="bool", required=False),
         vars=dict(type="dict", default={}, required=False),
         volatile=dict(type="bool", required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_service_template_info.py
+++ b/plugins/modules/icinga_service_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_servicegroup.py
+++ b/plugins/modules/icinga_servicegroup.py
@@ -113,6 +113,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         assign_filter=dict(required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_servicegroup_info.py
+++ b/plugins/modules/icinga_servicegroup_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_serviceset.py
+++ b/plugins/modules/icinga_serviceset.py
@@ -110,6 +110,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_timeperiod.py
+++ b/plugins/modules/icinga_timeperiod.py
@@ -126,6 +126,7 @@ def main():
         display_name=dict(required=False),
         imports=dict(type="list", elements="str", default=[], required=False),
         ranges=dict(type="dict", required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_timeperiod_info.py
+++ b/plugins/modules/icinga_timeperiod_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_timeperiod_template.py
+++ b/plugins/modules/icinga_timeperiod_template.py
@@ -181,6 +181,7 @@ def main():
             aliases=["include_period"],
         ),
         update_method=dict(required=False, default="LegacyTimePeriod"),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_timeperiod_template_info.py
+++ b/plugins/modules/icinga_timeperiod_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user.py
+++ b/plugins/modules/icinga_user.py
@@ -156,6 +156,7 @@ def main():
         period=dict(required=False),
         groups=dict(type="list", elements="str", required=False),
         vars=dict(type="dict", default={}, required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user_group.py
+++ b/plugins/modules/icinga_user_group.py
@@ -112,6 +112,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         disabled=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user_group_info.py
+++ b/plugins/modules/icinga_user_group_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user_info.py
+++ b/plugins/modules/icinga_user_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user_template.py
+++ b/plugins/modules/icinga_user_template.py
@@ -132,6 +132,7 @@ def main():
         enable_notifications=dict(type="bool", required=False),
         vars=dict(type="dict", default={}, required=False),
         zone=dict(required=False, default=None),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_user_template_info.py
+++ b/plugins/modules/icinga_user_template_info.py
@@ -89,6 +89,7 @@ def main():
         url=dict(required=True),
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_zone.py
+++ b/plugins/modules/icinga_zone.py
@@ -112,6 +112,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         is_global=dict(required=False, type="bool", default=False),
         parent=dict(required=False),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module

--- a/plugins/modules/icinga_zone_info.py
+++ b/plugins/modules/icinga_zone_info.py
@@ -96,6 +96,7 @@ def main():
         query=dict(type="str", required=False, default=""),
         resolved=dict(type="bool", default=False, choices=[True, False]),
         external=dict(type="bool", default=False, choices=[True, False]),
+        api_timeout=dict(required=False, default=10, type="int"),
     )
 
     # Define the main module


### PR DESCRIPTION
We have a huge number of hosts and host groups which use apply rules based on host vars.

Now it takes a lot of time for Director to automatically reassign hosts to groups after every update to a single group.

This resulted in timeout errors during such operations using the `icinga_hostgroup`. Because of that, we implemented a timeout option for this module to allow it to wait for long transactions.

See related issue in Icinga2 Director module repo: https://github.com/Icinga/icingaweb2-module-director/issues/1251