### PR TITLE
add 'groups' parameter to task 'icinga_user.yml'

### DIFF
--- a/roles/ansible_icinga/tasks/icinga_user.yml
+++ b/roles/ansible_icinga/tasks/icinga_user.yml
@@ -17,6 +17,7 @@
     period: "{{ user.period | default(omit) }}"
     disabled: "{{ user.disabled | default(omit) }}"
     email: "{{ user.email | default(icinga_user_email) }}"
+    groups: "{{ user.groups | default(omit) }}"
     vars: "{{ user.vars | default(omit) }}"
   retries: 3
   delay: 3


### PR DESCRIPTION
(possible) fix for bug [#283](https://github.com/telekom-mms/ansible-collection-icinga-director/issues/283#issue-3124576029)