### PR TITLE
Add zone option for icinga_user_group module

### DIFF
--- a/docs/icinga_user_group.rst
+++ b/docs/icinga_user_group.rst
@@ -40,6 +40,10 @@ Parameters
     Disabled objects will not be deployed.
 
 
+  zone (optional, str, None)
+    Set the zone.
+
+
   append (optional, bool, None)
     Do not overwrite the whole object but instead append the defined properties.
 
@@ -138,6 +142,7 @@ Examples
         url_password: "{{ icinga_pass }}"
         object_name: "onCall"
         disabled: false
+        zone: "foozone"
 
     - name: Update user group
       telekom_mms.icinga_director.icinga_user_group:

--- a/examples/icinga_user_group.yml
+++ b/examples/icinga_user_group.yml
@@ -7,6 +7,7 @@
     url_password: "{{ icinga_pass }}"
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
 - name: Update user group
   telekom_mms.icinga_director.icinga_user_group:
     state: present

--- a/plugins/modules/icinga_user_group.py
+++ b/plugins/modules/icinga_user_group.py
@@ -58,6 +58,10 @@ options:
     type: bool
     default: false
     choices: [true, false]
+  zone:
+    description:
+      - Set the zone.
+    type: str
   append:
     description:
       - Do not overwrite the whole object but instead append the defined properties.
@@ -77,6 +81,7 @@ EXAMPLES = """
     url_password: "{{ icinga_pass }}"
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
 
 - name: Update user group
   telekom_mms.icinga_director.icinga_user_group:
@@ -112,6 +117,7 @@ def main():
         object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         disabled=dict(type="bool", default=False, choices=[True, False]),
+        zone=dict(required=False, default=None),
         api_timeout=dict(required=False, default=10, type="int"),
     )
 
@@ -124,6 +130,7 @@ def main():
         "object_name",
         "display_name",
         "disabled",
+        "zone",
     ]
 
     data = {}

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_user_group.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_user_group.yml
@@ -7,6 +7,7 @@
     url_password: "{{ icinga_pass }}"
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
 - name: Update user group
   telekom_mms.icinga_director.icinga_user_group:
     state: absent

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_group.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_group.yml
@@ -7,6 +7,7 @@
     url_password: "{{ icinga_pass }}"
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
 - name: Update user group
   telekom_mms.icinga_director.icinga_user_group:
     state: present

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user_group.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user_group.yml
@@ -7,6 +7,7 @@
     url_password: "{{ icinga_pass }}"
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
   ignore_errors: true
   register: result
 - assert:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_group.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_group.yml
@@ -7,6 +7,7 @@
     url_password: iamwrong
     object_name: "onCall"
     disabled: false
+    zone: "foozone"
   ignore_errors: true
   register: result
 - assert:


### PR DESCRIPTION
We have discovered that by default the `icinga_user_group` module creates a group without a zone specified.

In our case we need this to be set to "global-templates" as otherwise it breaks configuration propagation to the satellites.

This PR adds the `zone` option to the module and fixes the issue we've been facing.