### PR TITLE
Fix: remove default for states parameter in icinga_dependency_apply

### DIFF
--- a/plugins/modules/icinga_dependency_apply.py
+++ b/plugins/modules/icinga_dependency_apply.py
@@ -103,7 +103,6 @@ options:
     required: false
     type: list
     elements: str
-    default: []
   append:
     description:
       - Do not overwrite the whole object but instead append the defined properties.
@@ -196,7 +195,6 @@ def main():
         states=dict(
             type="list",
             elements="str",
-            default=[],
             required=False,
             choices=["Critical", "Down", "OK", "Unknown", "Up", "Warning"]
         ),


### PR DESCRIPTION
Fixes a problem with the data key states on the dependency apply plugin, the default [] empty list is not needed, if set the plugin try to update as changed the object at every run (the id on director changes accordingly).
Without the default value all it's working and the existing object is not recreated.