### PR TITLE
fix: prevent simultaneous deploy handler

### DIFF
--- a/roles/ansible_icinga/handlers/main.yml
+++ b/roles/ansible_icinga/handlers/main.yml
@@ -12,3 +12,4 @@
     timeout: "{{ icinga_deploy_timeout | default(omit) }}"
   when: icinga_deploy_config | bool
   listen: config_deploy
+  throttle: 1


### PR DESCRIPTION
Fixes the issue with concurrent deployments to the same director described in #322 